### PR TITLE
vsize is already in bytes

### DIFF
--- a/lib/providers/linux.js
+++ b/lib/providers/linux.js
@@ -118,7 +118,7 @@ function calculateMemoryUsage(sysinfo, stat) {
 }
 
 function calculateVirtualMemoryUsage(sysinfo, stat) {
-  return stat.vsize * sysinfo.PAGE_SIZE;
+  return stat.vsize /* * sysinfo.PAGE_SIZE*/;
 }
 
 function getUptime(callback) {


### PR DESCRIPTION
vsize is already in bytes.
according to man page for proc:

> ```
>           (23) vsize  %lu
>                     Virtual memory size in bytes.
> ```
